### PR TITLE
Add ability to split up weekly events into Sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ token.json
 __pycache__
 venv
 .vscode
+sections.json

--- a/README.md
+++ b/README.md
@@ -35,3 +35,10 @@ For re-usability, you may want to save these in an `.env` file.
 ### Run the function
 
 To run the code to send an email, run `python send_email.py`.
+
+### Sections
+It is possible to split the week's events into sections using a file called `sections.json`. A template file (`sections.template.json`) is provided in this repository for you to copy and modify as you need. The code evaluates the sections in the order they appear in the JSON file. The fields are as follows:
+- `title` - the title of the section, to be displayed on the email.
+- `displayTitle` - whether you want to display the title on the email. You might want to set this to `False` if you only have one section.
+- `default` - if this is set to True, anything which does not match a section higher up the array will match this one.
+- `filters` - words to look for in the **description** of the event. If any of these words are found in the description, the event is matched to this section.

--- a/events.py
+++ b/events.py
@@ -1,0 +1,113 @@
+from datetime import datetime, timezone
+from typing import List
+from date_string import get_date_string
+from icalendar import Event as IcalEvent
+
+
+def get_time_string(date: datetime) -> str:
+    minute = date.minute if date.minute >= 10 else f"0{date.minute}"
+    return f"{date.hour}:{minute}"
+
+
+class Event:
+    title: str
+    dates: List[dict]
+    location: str
+    description: str
+
+    def __init__(self, ical_data: IcalEvent) -> None:
+        self.title = ical_data.get("SUMMARY")
+        self.dates = [
+            {
+                "start_time": ical_data.get("DTSTART").dt,
+                "end_time": ical_data.get("DTEND").dt,
+            }
+        ]
+        self.location = ical_data.get("LOCATION")
+        self.description = ical_data.get("DESCRIPTION")
+
+    def in_next_week(self) -> bool:
+        now = datetime.now(timezone.utc)
+        start_time = self.dates[0]["start_time"]
+        return (start_time - now).days >= 0 and (start_time - now).days <= 7
+
+    def in_mid_future(self) -> bool:
+        now = datetime.now(timezone.utc)
+        start_time = self.dates[0]["start_time"]
+        return (start_time - now).days >= 0 and (start_time - now).days < 90
+
+    def merge_event(self, new_event: "Event") -> None:
+        self.dates += new_event.dates
+
+    def get_datetime_string(self) -> str:
+        if len(self.dates) == 1:
+            start_time: datetime = self.dates[0]["start_time"]
+            end_time: datetime = self.dates[0]["end_time"]
+            # Option 1: One date
+            if start_time.day == end_time.day and start_time.month == end_time.month:
+                return f"{get_date_string(start_time)}, {get_time_string(start_time)} - {get_time_string(end_time)}"
+            # Option 2: Multiple dates, one continuous event
+            return f"{get_date_string(start_time)} {get_time_string(start_time)} - {get_date_string(end_time)} {get_time_string(end_time)}"
+        # Option 3: Multiple events
+        time_map: dict[str, list] = {}
+        for date in self.dates:
+            date_string = get_date_string(date["start_time"])
+            time_string = f"{get_time_string(date['start_time'])} - {get_time_string(date['end_time'])}"
+            if time_string in time_map:
+                time_map[time_string].append(date_string)
+            else:
+                time_map[time_string] = [date_string]
+        times = list(time_map.keys())
+        datetime_string = ""
+        for key in times:
+            time_string = ""
+            for date in time_map[key]:
+                time_string += f"{date}, "
+            time_string = f"{time_string[:-2]} at {key}"
+            datetime_string += time_string
+        return datetime_string
+
+    def format_for_email(self) -> str:
+        formatted_event = f"<h3>{self.title}</h3>"
+        formatted_event += (
+            f"<p><b>{self.location}, {self.get_datetime_string()}</b></p>"
+        )
+        formatted_event += f"<p>{self.description}<p>"
+        return formatted_event
+
+
+def get_this_weeks_events(events: List[Event]) -> List[Event]:
+    events_this_week: List[Event] = []
+    for event in events:
+        if not event.in_next_week():
+            continue
+        new_event = True
+        for event_to_compare in events_this_week:
+            if event_to_compare.title == event.title:
+                event_to_compare.merge_event(event)
+                new_event = False
+                continue
+        if new_event:
+            events_this_week.append(event)
+    return events_this_week
+
+
+def get_unique_future_events(
+    events: List[Event], this_weeks_events: List[Event]
+) -> List[Event]:
+    unique_events: List[Event] = []
+    this_weeks_event_titles = [event.title for event in this_weeks_events]
+    for event in events:
+        if not event.in_mid_future():
+            continue
+        if event.title in this_weeks_event_titles:
+            continue
+        new_event = True
+        for event_to_compare in unique_events:
+            if event_to_compare.title == event.title:
+                event_to_compare.merge_event(event)
+                new_event = False
+                continue
+        if new_event:
+            unique_events.append(event)
+    return unique_events

--- a/get_events.py
+++ b/get_events.py
@@ -18,14 +18,14 @@ def create_event_email() -> str:
     calendar = icalendar.Calendar.from_ical(text)
     events = [Event(eventData) for eventData in calendar.events]
     email = ""
-    email += "<h2>This Week's Events</h2>"
+    email += "<h1>This Week's Events</h1>"
     email += f"<p>For full details of all events, please see our website on <a href=https://www.achurchnearyou.com/church/{CHURCH_ID}/>A Church Near You.</a>"
     this_weeks_events = get_this_weeks_events(events)
     sections = get_sections()
     populate_section_events(sections, this_weeks_events)
     for section in sections:
         email += section.create_section_email()
-    email += "<h2>Future Events</h2>"
+    email += "<h1>Future Events</h1>"
     for event in get_unique_future_events(events, this_weeks_events):
         email += event.format_for_email()
     email += f"<br/>If you have an event you would like to advertise, please contact the church at {CONTACT_EMAIL}"

--- a/get_events.py
+++ b/get_events.py
@@ -1,117 +1,11 @@
 import os
 import icalendar
 import requests
-from datetime import datetime, timezone
-from typing import List
-from icalendar import Event as IcalEvent
-from date_string import get_date_string
+from sections import get_sections, populate_section_events
+from events import Event, get_this_weeks_events, get_unique_future_events
 
 CONTACT_EMAIL = os.environ.get("CONTACT_EMAIL")
 CHURCH_ID = os.environ.get("CHURCH_ID")
-
-
-def get_time_string(date: datetime) -> str:
-    minute = date.minute if date.minute >= 10 else f"0{date.minute}"
-    return f"{date.hour}:{minute}"
-
-
-class Event:
-    def __init__(self, ical_data: IcalEvent) -> None:
-        self.title = ical_data.get("SUMMARY")
-        self.dates = [
-            {
-                "start_time": ical_data.get("DTSTART").dt,
-                "end_time": ical_data.get("DTEND").dt,
-            }
-        ]
-        self.location = ical_data.get("LOCATION")
-        self.description = ical_data.get("DESCRIPTION")
-
-    def in_next_week(self) -> bool:
-        now = datetime.now(timezone.utc)
-        start_time = self.dates[0]["start_time"]
-        return (start_time - now).days >= 0 and (start_time - now).days <= 7
-
-    def in_mid_future(self) -> bool:
-        now = datetime.now(timezone.utc)
-        start_time = self.dates[0]["start_time"]
-        return (start_time - now).days >= 0 and (start_time - now).days < 90
-
-    def merge_event(self, new_event: "Event") -> None:
-        self.dates += new_event.dates
-
-    def get_datetime_string(self) -> str:
-        if len(self.dates) == 1:
-            start_time: datetime = self.dates[0]["start_time"]
-            end_time: datetime = self.dates[0]["end_time"]
-            # Option 1: One date
-            if start_time.day == end_time.day and start_time.month == end_time.month:
-                return f"{get_date_string(start_time)}, {get_time_string(start_time)} - {get_time_string(end_time)}"
-            # Option 2: Multiple dates, one continuous event
-            return f"{get_date_string(start_time)} {get_time_string(start_time)} - {get_date_string(end_time)} {get_time_string(end_time)}"
-        # Option 3: Multiple events
-        time_map: dict[str, list] = {}
-        for date in self.dates:
-            date_string = get_date_string(date["start_time"])
-            time_string = f"{get_time_string(date['start_time'])} - {get_time_string(date['end_time'])}"
-            if time_string in time_map:
-                time_map[time_string].append(date_string)
-            else:
-                time_map[time_string] = [date_string]
-        times = list(time_map.keys())
-        datetime_string = ""
-        for key in times:
-            time_string = ""
-            for date in time_map[key]:
-                time_string += f"{date}, "
-            time_string = f"{time_string[:-2]} at {key}"
-            datetime_string += time_string
-        return datetime_string
-
-    def format_for_email(self) -> str:
-        formatted_event = f"<h3>{self.title}</h3>"
-        formatted_event += (
-            f"<p><b>{self.location}, {self.get_datetime_string()}</b></p>"
-        )
-        formatted_event += f"<p>{self.description}<p>"
-        return formatted_event
-
-
-def get_this_weeks_events(events: List[Event]) -> List[Event]:
-    events_this_week: List[Event] = []
-    for event in events:
-        if not event.in_next_week():
-            continue
-        new_event = True
-        for event_to_compare in events_this_week:
-            if event_to_compare.title == event.title:
-                event_to_compare.merge_event(event)
-                new_event = False
-                continue
-        if new_event:
-            events_this_week.append(event)
-    return events_this_week
-
-
-def get_unique_future_events(
-    events: List[Event], this_weeks_events: List[Event]
-) -> List[Event]:
-    unique_events: List[Event] = []
-    this_weeks_event_titles = [event.title for event in this_weeks_events]
-    for event in events:
-        if not event.in_mid_future():
-            continue
-        if event.title in this_weeks_event_titles:
-            continue
-        new_event = True
-        for event_to_compare in unique_events:
-            if event_to_compare.title == event.title:
-                event_to_compare.merge_event(event)
-                new_event = False
-                continue
-        if new_event:
-            unique_events.append(event)
-    return unique_events
 
 
 def create_event_email() -> str:

--- a/get_events.py
+++ b/get_events.py
@@ -21,8 +21,10 @@ def create_event_email() -> str:
     email += "<h2>This Week's Events</h2>"
     email += f"<p>For full details of all events, please see our website on <a href=https://www.achurchnearyou.com/church/{CHURCH_ID}/>A Church Near You.</a>"
     this_weeks_events = get_this_weeks_events(events)
-    for event in this_weeks_events:
-        email += event.format_for_email()
+    sections = get_sections()
+    populate_section_events(sections, this_weeks_events)
+    for section in sections:
+        email += section.create_section_email()
     email += "<h2>Future Events</h2>"
     for event in get_unique_future_events(events, this_weeks_events):
         email += event.format_for_email()

--- a/get_updates.py
+++ b/get_updates.py
@@ -52,5 +52,5 @@ def create_update_email() -> str:
         if update.in_date_range():
             update_email += update.format_for_email()
     if len(update_email) > 0:
-        return "<h2>Updates and Notices</h2>" + update_email
+        return "<h1>Updates and Notices</h1>" + update_email
     return ""

--- a/sections.py
+++ b/sections.py
@@ -31,7 +31,7 @@ class Section:
         self.events.append(event)
 
     def create_section_email(self) -> str:
-        email_string = f"<h3>{self.title}</h3>" if self.displayTitle else ""
+        email_string = f"<h2>{self.title}</h2>" if self.displayTitle else ""
         for event in self.events:
             email_string += event.format_for_email()
         return email_string

--- a/sections.py
+++ b/sections.py
@@ -1,0 +1,59 @@
+import json
+from typing import List
+
+from events import Event
+
+
+class Section:
+    title: str
+    displayTitle: bool
+    default: bool
+    filters: List[str]
+    events: List[Event]
+
+    def __init__(self, section_json: dict) -> None:
+        self.title = section_json["title"]
+        self.displayTitle = section_json["displayTitle"]
+        self.default = section_json["default"]
+        self.events = []
+        if not self.default:
+            self.filters = section_json["filters"]
+
+    def matches_event(self, event: Event) -> bool:
+        if self.default:
+            return True
+        for filter in self.filters:
+            if filter.upper() in event.description.upper():
+                return True
+        return False
+
+    def add_event(self, event: Event) -> None:
+        self.events.append(event)
+
+    def create_section_email(self) -> str:
+        email_string = f"<h3>{self.title}</h3>" if self.displayTitle else ""
+        for event in self.events:
+            email_string += event.format_for_email()
+        return email_string
+
+
+def get_sections() -> List[Section]:
+    try:
+        with open("sections.json") as f:
+            sections_json_array = json.load(f)
+            return [Section(section_json) for section_json in sections_json_array]
+    except:
+        default_section = {
+            "title": "Default",
+            "displayTitle": False,
+            "default": True,
+        }
+        return [Section(default_section)]
+
+
+def populate_section_events(sections: List[Section], events: List[Event]) -> None:
+    for event in events:
+        for section in sections:
+            if section.matches_event(event):
+                section.add_event(event)
+                break

--- a/sections.template.json
+++ b/sections.template.json
@@ -1,0 +1,16 @@
+[
+    {
+        "title": "Services",
+        "displayTitle": true,
+        "default": false,
+        "filters": [
+            "service",
+            "worship"
+        ]
+    },
+    {
+        "title": "Other events",
+        "displayTitle": true,
+        "default": true
+    }
+]

--- a/test_events.py
+++ b/test_events.py
@@ -4,8 +4,8 @@ import datetime as dt
 
 # import zoneinfo
 import unittest
-import get_events
-from get_events import (
+import events
+from events import (
     get_date_string,
     get_time_string,
     get_this_weeks_events,
@@ -43,7 +43,7 @@ class EventTestCase(unittest.TestCase):
         self.mock_event.add(
             "dtend", dt.datetime(2025, 6, 2, 11, 30, 0, tzinfo=dt.timezone.utc)
         )
-        event = get_events.Event(self.mock_event)
+        event = events.Event(self.mock_event)
         self.assertEqual(event.in_next_week(), True)
 
     def test_not_in_next_week(self):
@@ -53,7 +53,7 @@ class EventTestCase(unittest.TestCase):
         self.mock_event.add(
             "dtend", dt.datetime(2025, 6, 9, 11, 30, 0, tzinfo=dt.timezone.utc)
         )
-        event = get_events.Event(self.mock_event)
+        event = events.Event(self.mock_event)
         self.assertEqual(event.in_next_week(), False)
 
     def test_in_mid_future(self):
@@ -63,7 +63,7 @@ class EventTestCase(unittest.TestCase):
         self.mock_event.add(
             "dtend", dt.datetime(2025, 6, 8, 11, 30, 0, tzinfo=dt.timezone.utc)
         )
-        event = get_events.Event(self.mock_event)
+        event = events.Event(self.mock_event)
         self.assertEqual(event.in_mid_future(), True)
 
     def test_not_in_mid_future(self):
@@ -73,7 +73,7 @@ class EventTestCase(unittest.TestCase):
         self.mock_event.add(
             "dtend", dt.datetime(2025, 9, 8, 11, 30, 0, tzinfo=dt.timezone.utc)
         )
-        event = get_events.Event(self.mock_event)
+        event = events.Event(self.mock_event)
         self.assertEqual(event.in_mid_future(), False)
 
     def test_format_constituent_parts(self):
@@ -83,7 +83,7 @@ class EventTestCase(unittest.TestCase):
         self.mock_event.add(
             "dtend", dt.datetime(2025, 6, 2, 11, 30, 0, tzinfo=dt.timezone.utc)
         )
-        event = get_events.Event(self.mock_event)
+        event = events.Event(self.mock_event)
         formatted_email = event.format_for_email()
         self.assertIn("Morning Worship", formatted_email)
         self.assertIn("Join us this morning for a time of worship", formatted_email)
@@ -97,7 +97,7 @@ class EventTestCase(unittest.TestCase):
         self.mock_event.add(
             "dtend", dt.datetime(2025, 6, 2, 11, 30, 0, tzinfo=dt.timezone.utc)
         )
-        event = get_events.Event(self.mock_event)
+        event = events.Event(self.mock_event)
 
         ical_event_to_merge = create_ical_event(
             "Morning Worship",
@@ -106,7 +106,7 @@ class EventTestCase(unittest.TestCase):
             dt.datetime(2025, 6, 3, 10, 30, 0, tzinfo=dt.timezone.utc),
             dt.datetime(2025, 6, 3, 11, 30, 0, tzinfo=dt.timezone.utc),
         )
-        event_to_merge = get_events.Event(ical_event_to_merge)
+        event_to_merge = events.Event(ical_event_to_merge)
         event.merge_event(event_to_merge)
         formatted_email = event.format_for_email()
         self.assertIn("2 June 2025, 3 June 2025 at 10:30 - 11:30", formatted_email)
@@ -137,7 +137,7 @@ class TestFilterEvents(unittest.TestCase):
             dt.datetime(2025, 6, 3, 10, 30, 0, tzinfo=dt.timezone.utc),
             dt.datetime(2025, 6, 3, 11, 30, 0, tzinfo=dt.timezone.utc),
         )
-        self.event_1 = get_events.Event(event_1_ical)
+        self.event_1 = events.Event(event_1_ical)
 
         event_2_ical = create_ical_event(
             "Evening Worship",
@@ -146,7 +146,7 @@ class TestFilterEvents(unittest.TestCase):
             dt.datetime(2025, 6, 3, 18, 30, 0, tzinfo=dt.timezone.utc),
             dt.datetime(2025, 6, 3, 19, 30, 0, tzinfo=dt.timezone.utc),
         )
-        self.event_2 = get_events.Event(event_2_ical)
+        self.event_2 = events.Event(event_2_ical)
 
         event_2_repeater_ical = create_ical_event(
             "Evening Worship",
@@ -155,7 +155,7 @@ class TestFilterEvents(unittest.TestCase):
             dt.datetime(2025, 6, 4, 18, 30, 0, tzinfo=dt.timezone.utc),
             dt.datetime(2025, 6, 4, 19, 30, 0, tzinfo=dt.timezone.utc),
         )
-        self.event_2_repeater = get_events.Event(event_2_repeater_ical)
+        self.event_2_repeater = events.Event(event_2_repeater_ical)
 
         future_event_ical = create_ical_event(
             "Future Worship",
@@ -164,7 +164,7 @@ class TestFilterEvents(unittest.TestCase):
             dt.datetime(2025, 7, 4, 18, 30, 0, tzinfo=dt.timezone.utc),
             dt.datetime(2025, 7, 4, 19, 30, 0, tzinfo=dt.timezone.utc),
         )
-        self.future_event = get_events.Event(future_event_ical)
+        self.future_event = events.Event(future_event_ical)
 
         past_event_ical = create_ical_event(
             "Past Worship",
@@ -173,7 +173,7 @@ class TestFilterEvents(unittest.TestCase):
             dt.datetime(2025, 5, 4, 18, 30, 0, tzinfo=dt.timezone.utc),
             dt.datetime(2025, 5, 4, 19, 30, 0, tzinfo=dt.timezone.utc),
         )
-        self.past_event = get_events.Event(past_event_ical)
+        self.past_event = events.Event(past_event_ical)
 
     def test_get_this_weeks_events_merges_events(self):
         events = [self.event_1, self.event_2, self.event_2_repeater]
@@ -236,10 +236,10 @@ class TestFilterEvents(unittest.TestCase):
             dt.datetime(2025, 7, 5, 18, 30, 0, tzinfo=dt.timezone.utc),
             dt.datetime(2025, 7, 5, 19, 30, 0, tzinfo=dt.timezone.utc),
         )
-        future_event_repeater = get_events.Event(future_event_repeater_ical)
+        future_event_repeater = events.Event(future_event_repeater_ical)
 
-        events = [self.event_1, self.future_event, future_event_repeater]
-        this_weeks_events = get_unique_future_events(events, [])
+        event_list = [self.event_1, self.future_event, future_event_repeater]
+        this_weeks_events = get_unique_future_events(event_list, [])
         self.assertEqual(len(this_weeks_events), 2)
         self.assertEqual(this_weeks_events[0].title, "Morning Worship")
         self.assertEqual(this_weeks_events[1].title, "Future Worship")

--- a/test_get_updates.py
+++ b/test_get_updates.py
@@ -61,7 +61,7 @@ class CreateUpdateEmailTest(unittest.TestCase):
         ]
         update_objects_mock.return_value = [Update(update_1), Update(update_2)]
         update_email = create_update_email()
-        self.assertIn("<h2>Updates and Notices</h2>", update_email)
+        self.assertIn("<h1>Updates and Notices</h1>", update_email)
         self.assertIn("<h3>Hot Meals Needed</h3>", update_email)
         self.assertNotIn("<h3>New Curate</h3>", update_email)
 

--- a/test_sections.py
+++ b/test_sections.py
@@ -1,0 +1,139 @@
+import unittest
+
+from icalendar import Event
+import events
+from sections import Section, populate_section_events
+import datetime as dt
+
+
+class SectionTestCase(unittest.TestCase):
+    def setUp(self):
+        mock_event_data = Event()
+        mock_event_data.add("summary", "Test Event")
+        mock_event_data.add("location", "All Saints' Church")
+        mock_event_data.add("description", "Join us for a time of worship")
+        mock_event_data.add(
+            "dtstart", dt.datetime(2025, 6, 2, 10, 30, 0, tzinfo=dt.timezone.utc)
+        )
+        mock_event_data.add(
+            "dtend", dt.datetime(2025, 6, 2, 11, 30, 0, tzinfo=dt.timezone.utc)
+        )
+        self.mock_event = events.Event(mock_event_data)
+
+    def test_matches_matching_event(self):
+        section = Section(
+            {
+                "title": "Services",
+                "displayTitle": True,
+                "default": False,
+                "filters": ["Worship"],
+            }
+        )
+        matches_event = section.matches_event(self.mock_event)
+        self.assertEqual(matches_event, True)
+
+    def test_matches_default_event(self):
+        section = Section(
+            {
+                "title": "Other Events",
+                "displayTitle": True,
+                "default": True,
+            }
+        )
+        matches_event = section.matches_event(self.mock_event)
+        self.assertEqual(matches_event, True)
+
+    def test_does_not_match_different_event(self):
+        section = Section(
+            {
+                "title": "Outreach Events",
+                "displayTitle": True,
+                "default": False,
+                "filters": ["outreach"],
+            }
+        )
+        matches_event = section.matches_event(self.mock_event)
+        self.assertEqual(matches_event, False)
+
+    def test_adds_event(self):
+        section = Section(
+            {
+                "title": "Services",
+                "displayTitle": True,
+                "default": False,
+                "filters": ["outreach"],
+            }
+        )
+        section.add_event(self.mock_event)
+        self.assertEqual(section.events, [self.mock_event])
+
+    def test_creates_section_email(self):
+        section = Section(
+            {
+                "title": "Services",
+                "displayTitle": True,
+                "default": False,
+                "filters": ["outreach"],
+            }
+        )
+        section.add_event(self.mock_event)
+        email_format = section.create_section_email()
+        self.assertIn("Services", email_format)
+        self.assertIn(self.mock_event.format_for_email(), email_format)
+
+    def test_omits_header_when_specified(self):
+        section = Section(
+            {
+                "title": "All Events",
+                "displayTitle": False,
+                "default": True,
+            }
+        )
+        section.add_event(self.mock_event)
+        email_format = section.create_section_email()
+        self.assertNotIn("All Events", email_format)
+
+
+class PopulateSectionEventsTestCase(unittest.TestCase):
+    def setUp(self):
+        mock_event_data = Event()
+        mock_event_data.add("summary", "Test Event")
+        mock_event_data.add("location", "All Saints' Church")
+        mock_event_data.add("description", "Join us for a time of worship")
+        mock_event_data.add(
+            "dtstart", dt.datetime(2025, 6, 2, 10, 30, 0, tzinfo=dt.timezone.utc)
+        )
+        mock_event_data.add(
+            "dtend", dt.datetime(2025, 6, 2, 11, 30, 0, tzinfo=dt.timezone.utc)
+        )
+        self.mock_event = events.Event(mock_event_data)
+
+    def test_populates_first_matching_section(self):
+        section_1 = Section(
+            {
+                "title": "Outreach",
+                "displayTitle": False,
+                "default": False,
+                "filters": ["outreach"],
+            }
+        )
+
+        section_2 = Section(
+            {
+                "title": "Services",
+                "displayTitle": False,
+                "default": False,
+                "filters": ["worship"],
+            }
+        )
+        section_3 = Section(
+            {
+                "title": "Other Events",
+                "displayTitle": False,
+                "default": True,
+            }
+        )
+        populate_section_events([section_1, section_2], [self.mock_event])
+        self.assertEqual(len(section_1.events), 0)
+        self.assertEqual(len(section_2.events), 1)
+        self.assertEqual(len(section_3.events), 0)


### PR DESCRIPTION
This PR introduces a way of splitting a weekly event into Sections using a JSON file. As a part of this, `events` and `sections` have been moved into their own files, and `get_events` is now a class which creates an email using both classes.